### PR TITLE
Add DiffJs command for comparing JavaScript files with main branch

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -307,6 +307,16 @@ vim.api.nvim_create_user_command("D", function(info)
   vim.cmd("norm zR<c-w>l")
 end, { nargs = "?" })
 
+vim.api.nvim_create_user_command("DiffJs", function(info)
+  local main_branch = info.args
+  if #main_branch == 0 then
+    main_branch = "main"
+  end
+  local js_path = vim.fn.expand("%:r") .. ".js"
+  vim.cmd("Gvdiffsplit " .. main_branch .. ":" .. js_path)
+  vim.cmd("norm zR<c-w>l")
+end, { nargs = "?" })
+
 vim.api.nvim_create_user_command("Re", function(info)
   --- @type string | nil
   local new_name = info.args


### PR DESCRIPTION
## Summary
Added a new `DiffJs` user command that enables quick comparison of JavaScript files against a specified branch (defaulting to `main`).

## Key Changes
- Created new `DiffJs` command that:
  - Accepts an optional branch name argument (defaults to `main` if not provided)
  - Automatically derives the `.js` file path from the current file by removing its extension
  - Opens a vertical diff split view using `Gvdiffsplit` to compare against the target branch
  - Unfolds all folds and focuses the right pane for better readability

## Implementation Details
- Follows the same pattern as the existing `D` command for consistency
- Uses `vim.fn.expand("%:r")` to get the current file path without extension, then appends `.js`
- Applies the same post-diff formatting (unfold all with `zR` and switch to right pane with `<c-w>l`)

https://claude.ai/code/session_01FebBCqeyPGJzTKtmYNwP1w