### PR TITLE
Port fish config to zsh

### DIFF
--- a/zsh/git.zsh
+++ b/zsh/git.zsh
@@ -1,0 +1,120 @@
+# ported back to zsh from fish/git.fish (which itself came from
+# https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/git/git.plugin.zsh)
+
+# Aliases
+alias g='git'
+alias gst='git status'
+alias gd='git diff'
+alias gdc='git diff --cached'
+alias gl='git pull'
+alias gup='git pull --rebase'
+alias gp='git push'
+
+alias gf='git fetch'
+alias gfa='git fetch --all'
+
+gdv() {
+  git diff -w "$@" | view -
+}
+
+alias gc='git commit -v'
+alias 'gc!'='git commit -v --amend'
+alias gca='git commit -v -a'
+alias 'gca!'='git commit -v -a --amend'
+alias gcmsg='git commit -m'
+alias gco='git checkout'
+alias gcm='git checkout master'
+alias gr='git remote'
+alias grv='git remote -v'
+alias grmv='git remote rename'
+alias grrm='git remote remove'
+alias grset='git remote set-url'
+alias grup='git remote update'
+alias grbi='git rebase -i'
+alias grbc='git rebase --continue'
+alias grba='git rebase --abort'
+alias gb='git branch'
+alias gba='git branch -a'
+alias gcount='git shortlog -sn'
+alias gcl='git config --list'
+alias gcp='git cherry-pick'
+alias glg='git log --stat --max-count=10'
+alias glgg='git log --graph --max-count=10'
+alias glgga='git log --graph --decorate --all'
+alias glo='git log --oneline'
+alias gss='git status -s'
+alias ga='git add'
+alias gm='git merge'
+alias grh='git reset HEAD'
+alias grhh='git reset HEAD --hard'
+alias gclean='git reset --hard && git clean -dfx'
+alias gwc='git whatchanged -p --abbrev-commit --pretty=medium'
+
+alias gpoat='git push origin --all && git push origin --tags'
+alias gmt='git mergetool --no-prompt'
+
+alias gg='git gui citool'
+alias gga='git gui citool --amend'
+alias gk='gitk --all --branches'
+
+alias gsts='git stash show --text'
+alias gsta='git stash'
+alias gstp='git stash pop'
+alias gstd='git stash drop'
+
+# Will cd into the top of the current repository
+# or submodule.
+alias grt='cd $(git rev-parse --show-toplevel || echo ".")'
+
+# Git and svn mix
+alias git-svn-dcommit-push='git svn dcommit && git push github master:svntrunk'
+
+alias gsr='git svn rebase'
+alias gsd='git svn dcommit'
+
+#
+# Will return the current branch name
+# Usage example: git pull origin $(current_branch)
+#
+current_branch() {
+  local ref
+  ref=$(git symbolic-ref HEAD 2> /dev/null) || \
+  ref=$(git rev-parse --short HEAD 2> /dev/null) || return
+  echo ${ref#refs/heads/}
+}
+
+current_repository() {
+  git symbolic-ref HEAD > /dev/null 2>&1 || \
+  git rev-parse --short HEAD > /dev/null 2>&1 || return
+  echo $(git remote -v | cut -d':' -f 2)
+}
+
+# these aliases take advantage of the previous function
+alias ggpull='git pull origin $(current_branch)'
+alias ggpur='git pull --rebase origin $(current_branch)'
+alias ggpush='git push origin $(current_branch)'
+alias ggpnp='git pull origin $(current_branch) && git push origin $(current_branch)'
+
+# Pretty log messages
+_git_log_prettily() {
+  if [ -n "$1" ]; then
+    git log --pretty=$1
+  fi
+}
+
+alias glp="_git_log_prettily"
+
+# Work In Progress (wip)
+# These features allow to pause a branch development and switch to another one (wip)
+# When you want to go back to work, just unwip it
+#
+# This function return a warning if the current branch is a wip
+work_in_progress() {
+  if git log -n 1 | grep -q -c wip; then
+    echo "WIP!!"
+  fi
+}
+
+# these alias commit and uncomit wip branches
+alias gwip='git add -A; git ls-files --deleted -z | xargs -0 git rm; git commit -m "wip" --no-verify'
+alias gunwip='git log -n 1 | grep -q -c wip && git reset HEAD~1'

--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -1,0 +1,33 @@
+# Two-line prompt, ported from fish/functions/fish_prompt.fish:
+# - green lines if the last command's exit status is OK, red otherwise
+# - your user name, in red if root or yellow otherwise
+# - your hostname, in cyan if ssh or blue otherwise
+# - the current path
+# - the current time
+# - the current git branch, if any
+#
+# ┬─[nino@Hattori:~/w/dashboard]─[11:39:00]─[G:main]
+# ╰─>$ echo here
+
+setopt prompt_subst
+
+if [ -n "$SSH_CLIENT" ]; then
+    _prompt_host_color=cyan
+else
+    _prompt_host_color=blue
+fi
+
+# Branch name only - no dirty/untracked/stash checks, they make the prompt slow
+# (the fish config disabled them too)
+_prompt_git_segment() {
+    local ref
+    ref=$(git symbolic-ref --short HEAD 2>/dev/null) \
+        || ref=$(git rev-parse --short HEAD 2>/dev/null) \
+        || return
+    print -rn -- "─%B%F{green}[%f%bG:$ref%B%F{green}]%f%b"
+}
+
+_prompt_status_color='%F{%(?.green.red)}'
+
+PROMPT="${_prompt_status_color}┬─%f%B%F{green}[%f%b%B%F{%(!.red.yellow)}%n%f%b%B@%b%B%F{${_prompt_host_color}}%m%f%b:%~%B%F{green}]%f%b─%B%F{green}[%f%b%*%B%F{green}]%f%b\$(_prompt_git_segment)
+${_prompt_status_color}╰─>%f%B%F{red}\$ %f%b"

--- a/zsh/worktrees.zsh
+++ b/zsh/worktrees.zsh
@@ -1,0 +1,103 @@
+# ported from fish/worktrees.fish
+
+wta() {
+    if [ $# -eq 0 ]; then
+        echo "Error: No branch name provided" >&2
+        return 1
+    fi
+
+    local worktree_path="$1"
+
+    # Pass the constructed path and any additional arguments to git worktree add
+    git worktree add ~/.claude-worktrees/$worktree_path "${@:2}"
+}
+
+wtam() {
+    wta "$1" -b "$1" $TRUNKBRANCHNAME
+}
+
+wtax() {
+    ## FYI this doesn't actually work yet
+    if [ $# -eq 0 ]; then
+        echo "Error: No branch name provided" >&2
+        return 1
+    fi
+
+    local branch_name="$1"
+    local current_dir=$(pwd)
+
+    # Get the git directory and repo root
+    local git_dir=$(git rev-parse --git-common-dir 2>/dev/null)
+
+    if [ -z "$git_dir" ]; then
+        echo "Error: Not in a git repository" >&2
+        return 1
+    fi
+
+    local repo_root=$(dirname $git_dir)
+    local worktree_path="$repo_root/worktree/$branch_name"
+
+    # Create new tmux session with the branch name, starting in current directory
+    tmux new-session -d -s $branch_name -c $current_dir
+
+    # Run gfmm && wta to create the worktree, then cd into it
+    tmux send-keys -t $branch_name:0 "gfmm && wta $branch_name -b $branch_name master && cd $worktree_path" C-m
+
+    # Wait a moment for the worktree to be created
+    sleep 1
+
+    # Open nvim in tab 0
+    tmux send-keys -t $branch_name:0 "nvim" C-m
+
+    # Create a new tab with two panes
+    tmux new-window -t $branch_name:1 -c $worktree_path
+
+    # Split the window vertically
+    tmux split-window -t $branch_name:1 -h -c $worktree_path
+
+    # Left pane: yarn && yarn dev
+    tmux send-keys -t $branch_name:1.0 "yarn && yarn dev" C-m
+
+    # Right pane: yarn exec tsc -- --noEmit --watch
+    tmux send-keys -t $branch_name:1.1 "yarn exec tsc -- --noEmit --watch" C-m
+
+    # Switch to the new session
+    tmux switch-client -t $branch_name
+}
+
+wtr() {
+    if [ $# -eq 0 ]; then
+        echo "Error: No worktree name provided" >&2
+        return 1
+    fi
+
+    local worktree_path=~/.claude-worktrees/$1
+
+    git worktree remove $worktree_path "${@:2}"
+}
+
+wtl() {
+    git worktree list
+}
+
+# Completion for git branches (for wta)
+_wta_branches() {
+    local -a branches
+    branches=(${(f)"$(git branch -a 2>/dev/null | sed -E 's/^\*?[[:space:]]*//' | sed -E 's/^remotes\///')"})
+    (( ${#branches} )) && _describe 'branch' branches
+}
+
+# Completion for existing worktrees (for wtr)
+_wtr_worktrees() {
+    local -a worktrees
+    if [ -d ~/.claude-worktrees ]; then
+        worktrees=(${(f)"$(find ~/.claude-worktrees -mindepth 1 -maxdepth 2 -type d -exec test -e '{}/.git' \; -print 2>/dev/null | sed "s|$HOME/.claude-worktrees/||")"})
+    fi
+    (( ${#worktrees} )) && _describe 'worktree' worktrees
+}
+
+# Set up completions (compinit must have run already)
+if (( $+functions[compdef] )); then
+    compdef _wta_branches wta
+    compdef _wtr_worktrees wtr
+fi

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -1,198 +1,176 @@
-# Path to your oh-my-zsh configuration.
-ZSH=$HOME/.oh-my-zsh
+# zsh config, ported from fish/config.fish
+#
+# Install:
+#   ln -sf ~/.config/zsh/zshrc ~/.zshrc
+#   brew install zsh-autosuggestions zsh-syntax-highlighting
+#   chsh -s $(which zsh)
 
-# Set name of the theme to load.
-# Look in ~/.oh-my-zsh/themes/
-# Optionally, if you set this to "random", it'll load a random theme each
-# time that oh-my-zsh is loaded.
-# default: ZSH_THEME="robbyrussell"
-ZSH_THEME="robbyrussell"
+# --- PATH ---------------------------------------------------------------
+typeset -U path  # dedupe, like fish_add_path
+path=(
+  /opt/homebrew/bin
+  /usr/local/bin
+  ~/.cargo/bin
+  ~/.config/scripts
+  ~/.local/context-osx-64/bin
+  ~/Developer/plinth/database-scripts/ninos-scripts/runnable
+  ~/.pixi/bin
+  ~/.modular/bin
+  ~/.local/bin
+  ~/secret-config2/scripts
+  $path
+)
 
-eval "$(direnv hook zsh)"
+# --- Environment --------------------------------------------------------
+export GHOSTCONF="$HOME/Library/Application Support/com.mitchellh.ghostty/config"
+export REACT_EDITOR='nvim'
+export EDITOR='nvim'
+export VISUAL='nvim'
+export CMAKE_EXPORT_COMPILE_COMMANDS=true
+export PACKERPATH=$HOME/.local/share/nvim/site/pack/packer/start
+export HOMEBREW_AUTO_UPDATE_SECS=600
+export CMAKE_GENERATOR=Ninja
+export CMAKE_PREFIX_PATH="/opt/homebrew:$CMAKE_PREFIX_PATH"
+export MAKEFLAGS="-j16"
+export VCPKG_ROOT=$HOME/code-friends/vcpkg
+export TRIPLET='arm64-osx'
+# export VCPKG_TARGET_ARCHITECTURE=x64
+export PKG_CONFIG_PATH="$VCPKG_ROOT/installed/$TRIPLET/lib/pkgconfig:$PKG_CONFIG_PATH"
+export CMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+path+=($VCPKG_ROOT)
 
-# Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
-# Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
-# Example format: plugins=(rails git textmate ruby lighthouse)
-# plugins=(git github osx history ruby rvm brew vi-mode)
-plugins=(git github macos history ruby brew wd vi-mode)
+# --- History (big, shared across sessions, deduped) ----------------------
+HISTFILE=~/.zsh_history
+HISTSIZE=100000
+SAVEHIST=100000
+setopt share_history hist_ignore_dups hist_ignore_space
 
-bindkey -v
-source $ZSH/oh-my-zsh.sh
+# --- Options & keybindings ------------------------------------------------
+bindkey -e                 # emacs bindings (^F, ^A, ^E …)
+setopt no_nomatch          # bash-like: pass unmatched globs through instead of erroring
+setopt interactive_comments
 
-setopt extended_glob
+# --- Completion -----------------------------------------------------------
+autoload -Uz compinit && compinit
+zstyle ':completion:*' menu select
+zstyle ':completion:*' matcher-list 'm:{a-z}={A-Za-z}'  # case-insensitive, like fish
 
-PROMPT="$PROMPT$ "
-
-# trash() {
-#   mv $1 ~/.Trash/$1-$(date +%H%M%S)
-# }
-
-
-local_ip_address() {
-  ipconfig getifaddr en0 || ipconfig getifaddr en7
-}
-
-# supposed to make the git prompt thing faster:
-function git_prompt_info() {
-  echo ""
-}
-# export DISABLE_AUTO_TITLE=true
-
-alias l='ls -l -h'
+# --- Aliases ---------------------------------------------------------------
+alias l='eza -lh'
+alias la='eza -lha'
 alias ls='ls'
+alias dum='diskutil unmount'
+alias js='jekyll serve --watch'
+alias pastepd='pbpaste | pandoc --smart --css css.css'
+alias pdtex='pandoc --template ~/Google\ Drive/Other\ Shit/pandoc-template.tex'
+alias osajsi='osascript -i -l JavaScript'
 alias v='nvim'
 alias vi='nvim'
 alias vim='nvim'
 alias vs='nvim -S ~/Prevsession.vim'
 alias bb='bbedit'
+alias vimserv='NVIM_LISTEN_ADDRESS=/tmp/neovim/neovim nvim'
+alias vv='/Applications/VV.app/Contents/Resources/bin/vv'
+alias zhrc='bbedit ~/.zshrc'
+alias zshrc='bbedit ~/.zshrc'
+alias zzr='source ~/.zshrc'
+alias tmconf='bbedit ~/.tmux.conf'
 alias tst='tig status'
 alias vc='nvim -S `ls | grep .vim | fzf`'
-alias ct='ctags -R .'
-alias uuid='uuidgen | tr -d "\n" | pbcopy'
+alias ydl="youtube-dl -f 'best[ext=mp4]' "
+alias yda="youtube-dl -x --audio-format mp3 "
+alias ct='ctags -R --exclude="**/node_modules/**" --exclude="node_modules/**/*" --exclude="models/classifier.json"'
+alias uuid='uuidgen | tr -d "\n" | tr "[:upper:]" "[:lower:]" | pbcopy'
+alias myarn='git checkout upstream/develop -- yarn.lock && yarn && git add yarn.lock'
+alias beep="echo -ne '\007' && sleep 1 && echo -ne '\007' && sleep 1 && echo -ne '\007'"
 alias com="git add . && git commit -m"
 alias awk='gawk'
 alias dockre='docker'
-
-if [ -f ~/.config/secret-config2/secret_zsh ]; then
-  source ~/.config/secret-config2/secret_zsh
-fi
-
-alias tnm='tig --no-merges'
-
 alias yran='yarn'
 alias yanr='yarn'
 alias ynar='yarn'
 alias ynra='yarn'
 alias ayrn='yarn'
-
-alias zzr='source ~/.zshrc'
-
-mcd() {
-  mkdir $1 && cd $1
-}
-
-
-
-co() {
-  local branch=`git lb | uniquelines | fzf`
-  if [ -z "$1" ]; then
-    gco $branch
-  elif [ "$1" = "merge" ]; then
-    eval "git merge \"$branch\""
-  fi
-  # local branch="$( git branch | sed s/\*/\ /g | awk '{ print $1 }' | fzf)"
-  # if [ ! -z $branch ]; then
-  #   if [ -z $1 ]; then
-  #     git checkout "$branch"
-  #   elif [ "$1" = "tig" ]; then
-  #     eval "tig \"$branch\""
-  #   else
-  #     local command="git $1 \"$branch\""
-  #     eval $command
-  #   fi
-  # fi
-}
-
-
+alias vlime='sbcl --load ~/.local/share/nvim/lazy/vlime/lisp/start-vlime.lisp'
+alias rvlime='rlwrap sbcl --load ~/.local/share/nvim/lazy/vlime/lisp/start-vlime.lisp'
+alias pddraft='pandoc --pdf-engine=lualatex -V papersize:a5 -V documentclass:scrarticle -V classoption:oneside -V indent -V fontfamily:ebgaramond-maths --top-level-division=section  --shift-heading-level-by=0 -V microtypeoptions:protrusion=true,expansion=true,tracking=true,factor=500,stretch=30,shrink=30'
+alias pddraft4='pandoc --pdf-engine=lualatex -V papersize:a4 -V documentclass:scrarticle -V classoption:oneside -V indent -V fontfamily:ebgaramond-maths --top-level-division=section  --shift-heading-level-by=0 -V microtypeoptions:protrusion=true,expansion=true,tracking=true,factor=500,stretch=30,shrink=30'
 alias stash='git stash --include-untracked'
 alias stpop='git stash pop'
+alias cl='claude'
 
-try_invoke() {
-  eval "$1 || $1 || $1"
+# --- Functions ---------------------------------------------------------------
+save() {
+  if [ $# -eq 0 ]; then
+    git commit && git push
+  else
+    git commit -m "$@" && git push
+  fi
 }
 
-
-# So you can press ctrl-s to save
-# v() {
-#     stty stop '' -ixoff; vim $*
-# }
-# this and stty stop '' -ixoff; make that ctrl is not intercepted by terminal
-# `Frozing' tty, so after any command terminal settings will be restored
-ttyctl -f
-
-# recursive line count
-countlines() {
-    find . -name $1 | xargs wc -l
+gfmm() {
+  git fetch origin $TRUNKBRANCHNAME:$TRUNKBRANCHNAME
 }
 
-# fortune -s rationality
-
-passgen(){
-    [ $# -eq 0 ] && 1="16"
-    tr -dc "[[:alnum:]!\"#$%&'()*+,./:;<=>?@\\_{|}~-]" < /dev/random |
-    head -c $1; echo
+saveall() {
+  git add .
+  save "$@"
 }
 
-matrix() {
-  echo -e "\e[1;40m" ; clear ; while :; do echo $LINES $COLUMNS $(( $RANDOM % $COLUMNS)) $(( $RANDOM % 72 )) ;sleep 0.05; done|awk '{ letters="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@#$%^&*()"; c=$4; letter=substr(letters,c,1);a[$3]=0;for (x in a) {o=a[x];a[x]=a[x]+1; printf "\033[%s;%sH\033[2;32m%s",o,x,letter; printf "\033[%s;%sH\033[1;37m%s\033[0;0H",a[x],x,letter;if (a[x] >= $1) { a[x]=0; } }}'
+mcd() {
+  mkdir "$1" && cd "$1"
 }
 
-export LIN='~/.config/nvim/lua/initialize.lua'
-export THING='~/.config/nvim/colors/thing.lua'
-export THINGLIGHT='~/.config/nvim/colors/thinglight.lua'
-export PLAINDARK='~/.config/nvim/colors/plaindark.lua'
-export SECRETZSH='~/.config/secret-config2/secret_zsh'
-export KITTYCONF='~/.config/kitty/kitty.conf'
+co() {
+  local branch=$(git lb | uniquelines | fzf)
+  if [ -z "$1" ]; then
+    gco "$branch"
+  elif [ "$1" = "merge" ]; then
+    git merge "$branch"
+  fi
+}
 
-PERL_MB_OPT="--install_base \"/Users/Nino/perl5\""; export PERL_MB_OPT;
-PERL_MM_OPT="INSTALL_BASE=/Users/Nino/perl5"; export PERL_MM_OPT;
+local_ip_address() {
+  ipconfig getifaddr en0 || ipconfig getifaddr en7
+}
 
-# To fix the weird python utf8 problem
-export LC_ALL=en_US.UTF-8
-export LANG=en_US.UTF-8
+cheat.sh() {
+  curl cheat.sh/$1
+}
+# completions on-the-fly, non-cached, because the actual command won't be cached anyway
+_cheat_sh() { compadd $(curl -s cheat.sh/:list) }
+compdef _cheat_sh cheat.sh
 
-export NVIM_LISTEN_ADDRESS=/tmp/nvimsocket
-export CMAKE_EXPORT_COMPILE_COMMANDS=true
+maybe_source() {
+  [ -f "$1" ] && source "$1"
+  return 0
+}
 
-# Set NVM dir if nvm is installed
-if hash nvm 2>/dev/null; then
-  NVM_DIR="/Users/Nino/.nvm"
-  . "/usr/local/opt/nvm/nvm.sh"
+# --- Prompt, git aliases, worktree helpers -----------------------------------
+source ~/.config/zsh/prompt.zsh
+source ~/.config/zsh/git.zsh
+source ~/.config/zsh/worktrees.zsh
+
+# --- Secret / machine-local config ----------------------------------------
+maybe_source ~/secret-config2/zsh/secret.zsh
+maybe_source ~/credentials
+
+# --- Tool hooks --------------------------------------------------------------
+command -v direnv >/dev/null && eval "$(direnv hook zsh)"
+
+# Lazy-load mise - use shims instead of full shell integration for faster startup
+if [ -f ~/.local/bin/mise ]; then
+  eval "$(~/.local/bin/mise activate zsh --shims)"
 fi
 
-# tabtab source for serverless package
-# uninstall by removing these lines or running `tabtab uninstall serverless`
-[[ -f /usr/local/lib/node_modules/serverless/node_modules/tabtab/.completions/serverless.zsh ]] && . /usr/local/lib/node_modules/serverless/node_modules/tabtab/.completions/serverless.zsh
-# tabtab source for sls package
-# uninstall by removing these lines or running `tabtab uninstall sls`
-[[ -f /usr/local/lib/node_modules/serverless/node_modules/tabtab/.completions/sls.zsh ]] && . /usr/local/lib/node_modules/serverless/node_modules/tabtab/.completions/sls.zsh
+maybe_source ~/.fzf.zsh
 
-# Fuzzy Finder
-export FZF_DEFAULT_COMMAND='fd --type f'
-
-# Setting PATH for Python 3.6
-# The original version is saved in .bash_profile.pysave
-# export PATH="/Library/Frameworks/Python.framework/Versions/3.6/bin:~/Library/Python/3.6/bin:${PATH}"
-# export PATH="/Library/Frameworks/Python.framework/Versions/3.6/bin:${PATH}"
-# if [ -n "$(command -v pyenv)" ]; then # Only if pyenv command exists
-#   eval "$(pyenv init -)"
-# fi
-#
-
-
-export PATH="$HOME/.config/scripts:${PATH}"
-export PATH="$HOME/.config/secret-config2/scripts:${PATH}"
-export PATH="$HOME/.local/bin:${PATH}"
-export TERM=screen-256color
-
-
-
-
-[ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
-[ -f ~/.secret_vars ] && source ~/.secret_vars
-
-
-export PATH=$PATH:/home/nino/.cargo/bin
-export PATH=$PATH:/Users/nino/.rustup/toolchains/stable-aarch64-apple-darwin/bin
-
-
-# For rm-improved
-export GRAVEYARD=~/.Trash
-
-# https://github.com/keybase/keybase-issues/issues/2798
-# export GPG_TTY=$(tty)
-eval "$(~/.local/bin/mise activate zsh)"
-
-export PATH=$PATH:/opt/homebrew/bin
-
-export PATH="/Users/Nino/.pixi/bin:$PATH"
+# --- Fish-style ghost text + syntax highlighting ------------------------------
+_brew_prefix=${HOMEBREW_PREFIX:-/opt/homebrew}
+if [ -f $_brew_prefix/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]; then
+  source $_brew_prefix/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+  ZSH_AUTOSUGGEST_STRATEGY=(history completion)  # suggest from history first, then completions
+  bindkey '^F' autosuggest-accept                # accept the ghost suggestion with ^F, like fish
+fi
+# must stay at the very end of .zshrc
+maybe_source $_brew_prefix/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh


### PR DESCRIPTION
Replace the outdated oh-my-zsh zshrc with a port of the current fish
setup, for switching the login shell back to zsh:

- zsh/zshrc: PATH, env vars, aliases, and functions from fish/config.fish,
  plus fish-like history/completion settings and zsh-autosuggestions
  (ghost text, ^F to accept) + zsh-syntax-highlighting via Homebrew
- zsh/git.zsh: port of fish/git.fish (also fixes the broken
  current_branch helper)
- zsh/worktrees.zsh: port of fish/worktrees.fish incl. completions
- zsh/prompt.zsh: port of the two-line fish prompt, branch-only git
  segment (no dirty-state checks, matching the fish speed tweaks)

Install: ln -sf ~/.config/zsh/zshrc ~/.zshrc

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Cc8BBPhf2C2o75sLw6NMyY