### PR TITLE
ci: declare token scope and let dependabot track actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,9 @@ updates:
     directory: "/yarn/global"
     schedule:
       interval: "weekly"
+  # Without this, the actions in .github/workflows have no update path and go
+  # stale silently — which is how checkout stayed on v3.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
`rust.yml` had no `permissions:` block, so the job ran with the repo-default `GITHUB_TOKEN` scope. It only builds and tests, so `contents: read` covers it.

Also adds the `github-actions` ecosystem to `dependabot.yml`. Without it the workflow actions have no update path and go stale silently — which is why `actions/checkout` here is still on `v3`. Once this merges, Dependabot should open that bump on its own rather than me doing it by hand.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShCLqHALmFvVAYuZZbtqy1)_